### PR TITLE
Fix lastRespawn reporting

### DIFF
--- a/index.js
+++ b/index.js
@@ -339,7 +339,7 @@ program
                       val = moment.humanizeDuration(val);
                     }
                     else if (k === 'lastRespawn') {
-                      val = moment.humanizeDuration(-1 * val, true);
+                      val = moment.humanizeDuration(-1 * (new Date().getTime() - val), true);
                     }
                     return k + ': ' + val;
                   })


### PR DESCRIPTION
As described here: https://github.com/amino/amino-drone/issues/3, `lastRespawn` is not reported correctly. This makes the duration calculation match the value reported by amino-drone, assuming PR is accepted: https://github.com/amino/amino-drone/pull/4.
